### PR TITLE
Fix builds on CI

### DIFF
--- a/.github/workflows/flake-lock-update.yml
+++ b/.github/workflows/flake-lock-update.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v1
+        uses: DeterminateSystems/nix-installer-action@v14
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v20
+        uses: DeterminateSystems/update-flake-lock@v24
         with:
           pr-title: "Update flake.lock"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - pretty: "Typecheck with Agda"
             derivation: scope-lib
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
-    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: nix build .#${{ matrix.derivation }} --print-build-logs

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ AGDA2HS = agda2hs
 FLAGS =
 LIBRARIES =
 
-.PHONY: app alllib clean clean-lib clean-agdai nix-tc nix-build
+.PHONY: build alllib clean clean-lib clean-agdai nix-tc nix-build
+
+build: cabal-build
 
 alllib: lib lib/Scope.hs lib/Scope/All.hs lib/Scope/Core.hs lib/Scope/Diff.hs lib/Scope/In.hs lib/Scope/Split.hs lib/Scope/Sub.hs
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,12 +14,14 @@
       let
         pkgs = import nixpkgs {inherit system;};
         agda2hs-lib = agda2hs.packages.${system}.agda2hs-lib;
+        agda2hsWithPackages = agda2hs.lib.${system}.withPackages;
+        agda2hs-custom = agda2hsWithPackages [agda2hs-lib];
         scope-lib = pkgs.agdaPackages.mkDerivation
           { pname = "scope";
             meta = {};
             version = "0.1.0.0";
             buildInputs = [
-              agda2hs.packages.${system}.agda2hs-lib
+              agda2hs-lib
             ];
             preBuild = ''
               echo "module Everything where" > Everything.agda
@@ -27,15 +29,8 @@
             '';
             src = ./.;
           };
-        helper = agda2hs.lib.${system};
-        agda2hs-drv = pkgs.callPackage (helper.agda2hs-expr) {
-          inherit self;
-          agda2hs = pkgs.haskellPackages.callPackage (helper.agda2hs-pkg "") {};
-          inherit (pkgs.haskellPackages) ghcWithPackages;
-        };
-        agda2hs-custom = agda2hs-drv.withPackages [agda2hs-lib];
         scope-pkg = import ./scope.nix;
-        scope-hs = pkgs.haskell.packages.ghc94.callPackage scope-pkg {agda2hs = agda2hs-custom;};
+        scope-hs = pkgs.haskellPackages.callPackage scope-pkg {agda2hs = agda2hs-custom;};
       in {
         packages = {
           inherit scope-hs scope-lib;

--- a/flake.nix
+++ b/flake.nix
@@ -39,5 +39,16 @@
         lib = {
           inherit scope-pkg;
         };
+
+        devShells.default = pkgs.haskellPackages.shellFor {
+          packages = p: with p; [scope-hs];
+          buildInputs = with pkgs.haskellPackages; [
+            cabal-install
+            cabal2nix
+            haskell-language-server
+            agda2hs-custom
+            (pkgs.agda.withPackages [ agda2hs-lib ])
+          ];
+        };
       });
 }

--- a/scope.cabal
+++ b/scope.cabal
@@ -9,7 +9,7 @@ author:             Jesper Cockx, Lucas Escot
 maintainer:         jesper@sikanda.be, lucas@escot.me
 -- copyright:
 build-type:         Simple
-extra-doc-files:    CHANGELOG.md
+--extra-doc-files:    CHANGELOG.md
 -- extra-source-files:
 
 common warnings
@@ -27,9 +27,8 @@ library
                     , Scope.In
                     , Scope.Split
                     , Scope.Sub
-
-    -- other-modules:
+    other-modules:    Utils.List
     -- other-extensions:
-    build-depends:    base >=4.17.0.0 && < 4.21
+    build-depends:    base >=4.17 && < 4.21
     hs-source-dirs:   lib
     default-language: GHC2021

--- a/scope.cabal
+++ b/scope.cabal
@@ -30,6 +30,6 @@ library
 
     -- other-modules:
     -- other-extensions:
-    build-depends:    base ^>=4.17.0.0
+    build-depends:    base >=4.17.0.0 && < 4.21
     hs-source-dirs:   lib
     default-language: GHC2021

--- a/scope.nix
+++ b/scope.nix
@@ -1,4 +1,4 @@
-# this package is produced by calling cabal2nix . in the parent directory
+# this package is produced by calling `cabal2nix .`
 # and then doing the following:
 # add an agda2hs argument
 # add buildTools = [agda2hs];

--- a/src/Scope/All.agda
+++ b/src/Scope/All.agda
@@ -127,12 +127,12 @@ opaque
   unfolding All lookupAll
 
   allLookup : (ls : All p α)
-            → All (λ el → ∃ (el ∈ α × p el) (λ (i , pi) → lookupAll ls i ≡ pi)) α
+            → All (λ el → ∃ (el ∈ α × p el) (λ (i , pri) → lookupAll ls i ≡ pri)) α
   allLookup List.ANil = List.ANil
   allLookup (List.ACons ph ls) =
     List.ACons
       ((inHere , ph) ⟨ lookupHere ls ph ⟩)
-      (mapAll (λ where ((i , pi) ⟨ lp ⟩) → ((inThere i) , pi) ⟨ lookupThere lp ⟩)
+      (mapAll (λ where ((i , pri) ⟨ lp ⟩) → ((inThere i) , pri) ⟨ lookupThere lp ⟩)
               (allLookup ls))
   {-# COMPILE AGDA2HS allLookup #-}
 


### PR DESCRIPTION
Aside from the cleanup in `flake.nix`:
* simple renaming in Scope.All to make agda2hs happy
* widen `base` constraints to match `agda-core`  and add `Utils.List` to `other-modules`
* comment out CHANGELOG.md from .cabal - we never had it and the nix build fails because of this