### PR TITLE
inScope

### DIFF
--- a/src/Scope/All.agda
+++ b/src/Scope/All.agda
@@ -46,12 +46,11 @@ opaque
   {-# COMPILE AGDA2HS allJoin #-}
 
 opaque
-  unfolding All Sub Split
+  unfolding All
 
   lookupAll : All p α → x ∈ α → p x
-  lookupAll ps                < EmptyR    > = getAllSingl ps
-  lookupAll (List.ACons px _) < ConsL x _ > = px
-  lookupAll (List.ACons _ ps) < ConsR x q > = lookupAll ps < q >
+  lookupAll (List.ACons pz pzs) (zero ⟨ IsZero refl ⟩) = pz
+  lookupAll (List.ACons _ pzs) (suc n ⟨ IsSuc pn ⟩) = lookupAll pzs (n ⟨ pn ⟩)
   {-# COMPILE AGDA2HS lookupAll #-}
 
   findAll : {q : Set}

--- a/src/Scope/All.agda
+++ b/src/Scope/All.agda
@@ -49,8 +49,8 @@ opaque
   unfolding All
 
   lookupAll : All p α → x ∈ α → p x
-  lookupAll (List.ACons pz pzs) (zero ⟨ IsZero refl ⟩) = pz
-  lookupAll (List.ACons _ pzs) (suc n ⟨ IsSuc pn ⟩) = lookupAll pzs (n ⟨ pn ⟩)
+  lookupAll (List.ACons pz pzs) (Zero  ⟨ IsZero  refl ⟩) = pz
+  lookupAll (List.ACons _ pzs) (Suc n ⟨ IsSuc pn ⟩) = lookupAll pzs (n ⟨ pn ⟩)
   {-# COMPILE AGDA2HS lookupAll #-}
 
   findAll : {q : Set}

--- a/src/Scope/Diff.agda
+++ b/src/Scope/Diff.agda
@@ -16,7 +16,7 @@ private variable
 opaque
   unfolding Sub
 
-  @0 diff : ∀ {α β : Scope name} → Sub α β → Scope name
+  @0 diff : ∀ {α β : Scope name} → α ⊆ β → Scope name
   diff (⟨ p ⟩ _) = p
 
   diff-left : (p : α ⋈ β ≡ γ) → diff (subLeft p) ≡ β
@@ -33,7 +33,7 @@ opaque
   diffSub p = subRight (splitDiff p)
   {-# COMPILE AGDA2HS diffSub inline #-}
 
-  diffCase : (p : α ⊆ β) → In x β
+  diffCase : (p : α ⊆ β) → x ∈ β
             → (x ∈ α → a) → (x ∈ diff p → a) → a
   diffCase p = inSplitCase (splitDiff p)
   {-# COMPILE AGDA2HS diffCase inline #-}
@@ -47,8 +47,8 @@ opaque
     in  < s >
   {-# COMPILE AGDA2HS diffSubTrans #-}
 
-diffCoerce : (p : α ⊆ β) (q : In x α) → diff q ⊆ diff (coerce p q)
-diffCoerce p q = diffSubTrans q p
+diffCoerce : (p : α ⊆ β) (q : x ∈ α) → diff (inToSub q) ⊆ diff (subTrans (inToSub q) p)
+diffCoerce p q = diffSubTrans (inToSub q) p
 {-# COMPILE AGDA2HS diffCoerce inline #-}
 
 opaque

--- a/src/Scope/In.agda
+++ b/src/Scope/In.agda
@@ -24,7 +24,7 @@ data IsNth (@0 x : name) : @0 Scope name → Nat → Set where
 
 inScope : @0 name → @0 Scope name → Set
 inScope x α = ∃ Nat (λ n → IsNth x α n)
-{-# COMPILE AGDA2HS inScope inline #-}
+{-# COMPILE AGDA2HS inScope #-}
 
 syntax inScope x α = x ∈ α
 
@@ -103,6 +103,7 @@ opaque
   inJoinCase r = inSplitCase (splitRefl r)
   {-# COMPILE AGDA2HS inJoinCase #-}
 
+opaque
   inBindCase : x ∈ (y ◃ α) → (@0 x ≡ y → a) → (x ∈ α → a) → a
   inBindCase {y = y} p f g = inJoinCase (rezz [ y ]) p (λ q → (inSingCase q f)) g
   {-# COMPILE AGDA2HS inBindCase #-}


### PR DESCRIPTION
Replace the definition of In with a De Bruijn indices (and a correctness proof) to have a unique proof that x ∈ α. Before several ones were possible so pastern matching and equality couldn't be used.