### PR TITLE
switch to versioned dependencies

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -17,6 +17,14 @@ jobs:
             derivation: scope-lib
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
-    - run: nix build .#${{ matrix.derivation }} --print-build-logs
+    - uses: nixbuild/nix-quick-install-action@v34
+      with:
+        nix_conf: |
+          keep-env-derivations = true
+          keep-outputs = true
+    - name: Restore and save Nix store
+      uses: nix-community/cache-nix-action@v6
+      with:
+        # restore and save a cache using this key
+        primary-key: nix-${{ matrix.derivation }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+    - run: nix build .#${{ matrix.derivation }} --cores 0 --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -10,15 +10,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1762358660,
-        "narHash": "sha256-K/a/tsTJBOX/pyxj7fM6G22EeCrm9sZ73dCdlCNCDh0=",
+        "lastModified": 1757086409,
+        "narHash": "sha256-ZhemGUY6V0cplSwDAXkny+s6yQWKDDShTiUotIDhTXY=",
         "owner": "agda",
         "repo": "agda2hs",
-        "rev": "ef10a1aecb6429024b792bcff8c4f60ceffd8f39",
+        "rev": "abc5e129424a42cebf9730c35401a8823667b595",
         "type": "github"
       },
       "original": {
         "owner": "agda",
+        "ref": "stable",
         "repo": "agda2hs",
         "type": "github"
       }
@@ -43,15 +44,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762362029,
-        "narHash": "sha256-RLoc/lFALLSKC0X0iwWZWnvC3SnTdy3crWb8S+5rr94=",
+        "lastModified": 1762286042,
+        "narHash": "sha256-OD5HsZ+sN7VvNucbrjiCz7CHF5zf9gP51YVJvPwYIH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc4ddab57f80e0a20b9ad9c6db8bacd1eb4eb19a",
+        "rev": "12c1f0253aa9a54fdf8ec8aecaafada64a111e24",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,10 @@
 {
   description = "Agda scope library";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.agda2hs = {
-    url = "github:agda/agda2hs";
+    url = "github:agda/agda2hs/stable";
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
   };


### PR DESCRIPTION
use unstable branch of nix and `stable` (latest release) of agda2hs